### PR TITLE
Return the address to main app on newKey action

### DIFF
--- a/packages/keyhub-vault-web/src/vault.js
+++ b/packages/keyhub-vault-web/src/vault.js
@@ -417,6 +417,7 @@ export default function loadVault(window, document, mainElement) {
             // callback to the parent window with result
             const run = () =>
               callback(null, {
+                address,
                 publicKey,
                 signature,
                 phoneNumber,
@@ -470,6 +471,7 @@ export default function loadVault(window, document, mainElement) {
             // callback to the parent window with result
             const run = () =>
               callback(null, {
+                address,
                 publicKey,
                 signature,
               })


### PR DESCRIPTION
## Description

Return the address to main app on newKey action.

Required for https://github.com/BlockchainZoo/eqh-client/pull/382

## Breakdown

- [x] add `address` property to callback result during `newUnprotectedKeyAndSign`
