### PR TITLE
Object.freeze() on all window properties and most built-in javascript methods

### DIFF
--- a/packages/keyhub-vault-web/public/index.html
+++ b/packages/keyhub-vault-web/public/index.html
@@ -39,9 +39,8 @@
     </div>
   </div>
 
-  <!-- <script src="js/main.bundle.js" crossorigin="anonymous" async></script> -->
-  <script src="index.js" crossorigin="anonymous" integrity="sha384-l8M+tR5GS8bMb/ZxczhnlkMiVnWYy+1w3qLKsnnV61Hp7iSrNIgh4SQXKujUdKW9"
-    async></script>
+  <!-- <script src="js/main.bundle.js" crossorigin="anonymous"></script> -->
+  <script src="index.js" crossorigin="anonymous" integrity="sha384-+isJnTc4jiixOwow2hI/J60PYfqpFh3bupkoBfqa7Vsj4tkb49QC67VWrqKRH/Pi"></script>
 
 </body>
 


### PR DESCRIPTION
## Description

As we are using built-in methods like `window.alert()` and `document.createElement()` inside `vault.js`, this PR makes sure that we are calling the original functions that we expect.

It freezes most browser built-in objects and make them immutable as soon as the page has loaded.
It also seals most standard javascript methods (from properties and from prototypes), preventing overwrite.

This provides an additional level of security against unauthorized monkey-patching via console or malicious scripts (injected by browser plugins after the page has loaded).

Note: If the user chooses to backup via SMS without protection with a transport secret, `window.openpgp.encrypt` receives a copy of the generated passphrase (cleartext). The reference to `window.openpgp` is retrieved lazily after the page has been loaded.

See: https://github.com/BlockchainZoo/keyhub-vault/blob/49eea1ddd176cba93d4474cf69c805a0addd3539/packages/keyhub-vault-web/src/vault.js#L105

## Breakdown

- [x] Add `freezeProps` and `freezeProtos` to `public/index.js` in `keyhub-vault-web`
