### PR TITLE
Simplify build scripts (codesign + subresource-integrity-hash)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,9 +72,6 @@ dist
 secrets.yml
 secrets.json
 
-# react-scripts
-build
-
 # awsmobilejs
 appsync-info.json
 aws-info.json

--- a/package-lock.json
+++ b/package-lock.json
@@ -3924,13 +3924,13 @@
       }
     },
     "data-urls": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.0.1.tgz",
-      "integrity": "sha512-0HdcMZzK6ubMUnsMmQmG0AcLQPvbvb47R0+7CCZQCYgcd8OUWG91CG7sM6GoXgjz+WLl4ArFzHtBMy/QqSF4eg==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-1.1.0.tgz",
+      "integrity": "sha512-YTWYI9se1P55u58gL5GkQHW4P6VJBJ5iBT+B5a7i2Tjadhv52paJG0qHX4A0OR6/t52odI64KP2YvFpkDOi3eQ==",
       "dev": true,
       "requires": {
         "abab": "^2.0.0",
-        "whatwg-mimetype": "^2.1.0",
+        "whatwg-mimetype": "^2.2.0",
         "whatwg-url": "^7.0.0"
       },
       "dependencies": {
@@ -7739,7 +7739,7 @@
     },
     "jest-get-type": {
       "version": "22.4.3",
-      "resolved": "https://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
+      "resolved": "http://registry.npmjs.org/jest-get-type/-/jest-get-type-22.4.3.tgz",
       "integrity": "sha512-/jsz0Y+V29w1chdXVygEKSz2nBoHoYqNShPe+QgxSNjAuP1i8+k4LbQNrfoliKej0P45sivkSCh7yiD6ubHS3w==",
       "dev": true
     },
@@ -9099,9 +9099,9 @@
       }
     },
     "merge": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.0.tgz",
-      "integrity": "sha1-dTHjnUlJwoGma4xabgJl6LBYlNo=",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/merge/-/merge-1.2.1.tgz",
+      "integrity": "sha512-VjFo4P5Whtj4vsLzsYBu5ayHhoHJ0UqNm7ibvShmbmoz7tGi0vXaoJbGdB+GmDMLUdg8DpQXEIeVDAe8MaABvQ==",
       "dev": true
     },
     "merge-stream": {
@@ -9537,13 +9537,13 @@
       }
     },
     "node-notifier": {
-      "version": "5.2.1",
-      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.2.1.tgz",
-      "integrity": "sha512-MIBs+AAd6dJ2SklbbE8RUDRlIVhU8MaNLh1A9SUZDUHPiZkWLFde6UNwG41yQHZEToHgJMXqyVZ9UcS/ReOVTg==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-5.3.0.tgz",
+      "integrity": "sha512-AhENzCSGZnZJgBARsUjnQ7DnZbzyP+HxlVXuD0xqAnvL8q+OqtSX7lGg9e8nHzwXkMMXNdVeqq4E2M3EUAqX6Q==",
       "dev": true,
       "requires": {
         "growly": "^1.3.0",
-        "semver": "^5.4.1",
+        "semver": "^5.5.0",
         "shellwords": "^0.1.1",
         "which": "^1.3.0"
       }
@@ -10554,9 +10554,9 @@
       "dev": true
     },
     "randomatic": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.0.tgz",
-      "integrity": "sha512-KnGPVE0lo2WoXxIZ7cPR8YBpiol4gsSuOwDSg410oHh80ZMp5EiypNqL2K4Z77vJn6lB5rap7IkAmcUlalcnBQ==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-3.1.1.tgz",
+      "integrity": "sha512-TuDE5KxZ0J461RVjrJZCJc+J+zCkTb1MbH9AQUq68sMhOMcy9jLcb3BrZKgp9q9Ncltdg4QVqWrH02W2EFFVYw==",
       "dev": true,
       "requires": {
         "is-number": "^4.0.0",
@@ -12967,6 +12967,16 @@
       "dev": true,
       "requires": {
         "errno": "~0.1.7"
+      }
+    },
+    "worker-loader": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
+      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
+      "dev": true,
+      "requires": {
+        "loader-utils": "^1.0.0",
+        "schema-utils": "^0.4.0"
       }
     },
     "wrap-ansi": {

--- a/package.json
+++ b/package.json
@@ -18,11 +18,12 @@
     "eslint-config-prettier": "^3.1.0",
     "eslint-plugin-import": "^2.13.0",
     "eslint-plugin-prettier": "^3.0.0",
-    "jest": "^23.4.0",
+    "jest": "^23.6.0",
     "lerna": "^3.4.3",
     "link-parent-bin": "^0.2.3",
     "prettier": "^1.14.3",
     "webpack": "^4.16.0",
-    "webpack-cli": "^3.0.8"
+    "webpack-cli": "^3.0.8",
+    "worker-loader": "^2.0.0"
   }
 }

--- a/packages/keyhub-vault-web/build/sri.hash.js
+++ b/packages/keyhub-vault-web/build/sri.hash.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const fs = require('fs')
+
+// eslint-disable-next-line import/no-extraneous-dependencies
+const ssri = require('ssri')
+
+const fileListToSRI = [
+  'dist/js/openpgp.worker.bundle.js',
+  'public/index.js',
+  'public/css/styles.css',
+  'public/css/main.css',
+]
+
+Promise.all(
+  fileListToSRI.map(filepath =>
+    ssri.fromStream(fs.createReadStream(filepath), { algorithms: ['sha384'] }).then(sri => {
+      console.info(`SRI of ${filepath}:`, sri.toString()) // eslint-disable-line no-console
+    })
+  )
+).catch(err => {
+  console.error('cannot hash:', err) // eslint-disable-line no-console
+})

--- a/packages/keyhub-vault-web/package-lock.json
+++ b/packages/keyhub-vault-web/package-lock.json
@@ -25,6 +25,14 @@
         "pend": "~1.2.0",
         "rimraf": "~2.2.8",
         "streamsink": "~1.2.0"
+      },
+      "dependencies": {
+        "mime": {
+          "version": "1.2.11",
+          "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
+          "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
+          "dev": true
+        }
       }
     },
     "address-rfc2822": {
@@ -35,12 +43,6 @@
       "requires": {
         "email-addresses": "^3.0.0"
       }
-    },
-    "ajv-keywords": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.2.0.tgz",
-      "integrity": "sha1-6GuBnGAs+IIa1jdBNpjx3sAhhHo=",
-      "dev": true
     },
     "amdefine": {
       "version": "1.0.1",
@@ -536,12 +538,6 @@
       "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ=",
       "dev": true
     },
-    "fast-json-stable-stringify": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
-      "dev": true
-    },
     "fd-slicer": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.0.1.tgz",
@@ -726,6 +722,11 @@
       "requires": {
         "repeating": "^2.0.0"
       }
+    },
+    "indexed-db-as-promised": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/indexed-db-as-promised/-/indexed-db-as-promised-0.1.0.tgz",
+      "integrity": "sha512-hqlNb1Qm+KdFvKqz6wxAVDYseuWVG0XJQauetDG3+c7Rr9YRi6l5b+psslom6uC4q2p1FbxXi3q2n6jt+PUp/w=="
     },
     "inflight": {
       "version": "1.0.6",
@@ -914,12 +915,6 @@
           "dev": true
         }
       }
-    },
-    "mime": {
-      "version": "1.2.11",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-1.2.11.tgz",
-      "integrity": "sha1-WCA+7Ybjpe8XrtK32evUfwpg3RA=",
-      "dev": true
     },
     "minimalistic-assert": {
       "version": "1.0.1",
@@ -1248,12 +1243,6 @@
         "pump": "^2.0.0"
       }
     },
-    "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
-    },
     "querystring": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
@@ -1392,42 +1381,6 @@
       "resolved": "http://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
       "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o=",
       "dev": true
-    },
-    "schema-utils": {
-      "version": "0.4.5",
-      "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-0.4.5.tgz",
-      "integrity": "sha512-yYrjb9TX2k/J1Y5UNy3KYdZq10xhYcF8nMpAW6o3hy6Q8WSIEf9lJHG/ePnOBfziPM3fvQwfOwa13U/Fh8qTfA==",
-      "dev": true,
-      "requires": {
-        "ajv": "^6.1.0",
-        "ajv-keywords": "^3.1.0"
-      },
-      "dependencies": {
-        "ajv": {
-          "version": "6.5.2",
-          "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.5.2.tgz",
-          "integrity": "sha512-hOs7GfvI6tUI1LfZddH82ky6mOMyTuY0mk7kE2pWpmhhUSkumzaTO5vbVwij39MdwPQWCV4Zv57Eo06NtL/GVA==",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "^2.0.1",
-            "fast-json-stable-stringify": "^2.0.0",
-            "json-schema-traverse": "^0.4.1",
-            "uri-js": "^4.2.1"
-          }
-        },
-        "fast-deep-equal": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
-          "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
-          "dev": true
-        },
-        "json-schema-traverse": {
-          "version": "0.4.1",
-          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-          "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-          "dev": true
-        }
-      }
     },
     "semver": {
       "version": "5.5.0",
@@ -1661,15 +1614,6 @@
         "imurmurhash": "^0.1.4"
       }
     },
-    "uri-js": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
-      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-      "dev": true,
-      "requires": {
-        "punycode": "^2.1.0"
-      }
-    },
     "url": {
       "version": "0.10.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
@@ -1708,16 +1652,6 @@
       "requires": {
         "spdx-correct": "^3.0.0",
         "spdx-expression-parse": "^3.0.0"
-      }
-    },
-    "worker-loader": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/worker-loader/-/worker-loader-2.0.0.tgz",
-      "integrity": "sha512-tnvNp4K3KQOpfRnD20m8xltE3eWh89Ye+5oj7wXEEHKac1P4oZ6p9oTj8/8ExqoSBnk9nu5Pr4nKfQ1hn2APJw==",
-      "dev": true,
-      "requires": {
-        "loader-utils": "^1.0.0",
-        "schema-utils": "^0.4.0"
       }
     },
     "wrappy": {

--- a/packages/keyhub-vault-web/package.json
+++ b/packages/keyhub-vault-web/package.json
@@ -8,7 +8,7 @@
     "start": "caddy",
     "test": "echo \"Error: no test specified\" && exit 1",
     "winlf": "(cat ./node_modules/openpgp/src/worker/worker.js | normalize-newline > ./node_modules/openpgp/src/worker/worker.js) && (cat ./node_modules/openpgp/dist/openpgp.min.js | normalize-newline > ./node_modules/openpgp/dist/openpgp.min.js)",
-    "prepare": "([ -e dist/js/openpgp.worker.bundle.js ] || browserify -p browserify-derequire -r openpgp/src/worker/worker -s openpgp -o dist/js/openpgp.worker.bundle.js) && webpack --config webpack.config.js --env.CODESIGN_PASSPHRASE=\"${CODESIGN_PASSPHRASE}\" --progress"
+    "prepare": "([ -e dist/js/openpgp.worker.bundle.js ] || browserify -p browserify-derequire -r openpgp/src/worker/worker -s openpgp -o dist/js/openpgp.worker.bundle.js) && node build/sri.hash.js && webpack --config webpack.config.js --env.STAGE=\"${STAGE}\" --env.CODESIGN_PASSPHRASE=\"${CODESIGN_PASSPHRASE}\" --progress"
   },
   "repository": {
     "type": "git",
@@ -36,7 +36,6 @@
     "serverless-plugin-cloudfront-lambda-edge": "^2.0.0",
     "serverless-s3-sync": "^1.7.1",
     "serverless-stack-output": "^0.2.3",
-    "ssri": "^6.0.0",
-    "worker-loader": "^2.0.0"
+    "ssri": "^6.0.0"
   }
 }


### PR DESCRIPTION
## Description

Simplify build scripts to make them shorter and easier to understand.

## Breakdown

- [x] Rewrite `packages/keyhub-vault-web/build/openpgp.sign.js`
- [x] Split code into `packages/keyhub-vault-web/build/sri.hash.js`
- [x] Move `worker-loader` dependency to root package.json
